### PR TITLE
Update install-ngx.sh

### DIFF
--- a/provisioners/install-ngx.sh
+++ b/provisioners/install-ngx.sh
@@ -1,5 +1,5 @@
 #install ngx-rocket
-sudo npm install -g generator-ngx-rocket
+sudo npm install -g generator-ngx-rocket@6.2.1
 #change to app directory
 cd /home/vagrant/
 mkdir starter_app


### PR DESCRIPTION
generator-ngx-rocket is now on version 7.0.0 and requires NodeJS 10.9 or above. Using version 6.2.1 fixes the problem of running the Angular application on Vagrant.